### PR TITLE
Add Kretes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ In Ukrainian :ukraine::
 * [Renovate](https://renovateapp.com/) - Automated dependency updates, for humans
 * [syncpack](https://github.com/JamieMason/syncpack)
 * [handpick](https://github.com/redaxmedia/handpick) - Handpick conditional dependencies like a boss
+* [Kretes](https://kretes.dev/) - A programming environment for building full-stack apps in TypeScript.
 
 ## Benchmarks
 


### PR DESCRIPTION
Kretes uses pnpm as the package manager. The integration between these tools is tight - it is not possible to use npm or yarn in Kretes.